### PR TITLE
Allow using a .js config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ npx ember-angle-brackets-codemod angle-brackets app/templates
 
 ### Skipping helpers
 
-To help the codemod disambiguate components and helpers, you can define a list of helpers from your application in a configuration file as follows:
+To help the codemod disambiguate components and helpers, you can define a list of helpers from your application in a configuration file as follows (`.json` and `.js` are supported):
 
 **config/anglebrackets-codemod-config.json**
 
@@ -66,6 +66,18 @@ To help the codemod disambiguate components and helpers, you can define a list o
   ]
 }
 ```
+
+**config/anglebrackets-codemod-config.js**
+
+```js
+module.exports = {
+  "helpers": [
+    "date-formatter", 
+    "info-pill"
+  ]
+}
+```
+
 The codemod will then ignore the above list of helpers and prevent them from being transformed into the new angle-brackets syntax.
 
 You can also disable the conversion of the built-in components `{{link-to}}`, `{{input}}` and `{{textarea}}` as follows:

--- a/package-lock.json
+++ b/package-lock.json
@@ -835,25 +835,25 @@
       }
     },
     "@glimmer/interfaces": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.41.0.tgz",
-      "integrity": "sha512-d0Ryj8iV3FiyMyT4QpwHNg2QFFEmdzI5cJFcbmC+OmuTe6eOQ52mLDlw1+D+a3ZDv8Jfj3l0QkEcEugCxDY+1Q=="
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.41.1.tgz",
+      "integrity": "sha512-Wdn0WJN0OScZ8n9l6ijlEXbUxd7a5cWIWrq9UVnlfXm/CuC78RVXA3hZAP1LH0uWepg7GxEl3Ax5bhWGstUKhw=="
     },
     "@glimmer/syntax": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.41.0.tgz",
-      "integrity": "sha512-sYmgUMdK0jX+3ZNX9C2TKvL1YZGsKIcXRicwnzoTC7F56z29CbSCc7o6Zf0CI4L2Q7FSnHDxldlSe48wBAr6vQ==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.41.1.tgz",
+      "integrity": "sha512-jkRRxA1Y2y3PUz3mKrVBmehLzPxYL50APcm/brY5yMYabduA/WxI88PgBP1GfeURJK9YUhVo5S4lspcWbm9V8Q==",
       "requires": {
-        "@glimmer/interfaces": "^0.41.0",
-        "@glimmer/util": "^0.41.0",
+        "@glimmer/interfaces": "^0.41.1",
+        "@glimmer/util": "^0.41.1",
         "handlebars": "^4.0.13",
         "simple-html-tokenizer": "^0.5.7"
       }
     },
     "@glimmer/util": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.41.0.tgz",
-      "integrity": "sha512-aKmQy62eRFhOZET9XmTB8MOA32G1FmD4d9HWL21OfdcGM4IbguRrWLMQc2DRh1YOE2AaT0PBrFrPmpNwFp5tpQ=="
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.41.1.tgz",
+      "integrity": "sha512-jpJvSB+OIUNcurfw8cue57h09xRkNPPXJF+Zqtgi4vMQo9Gb7mkHZX8+Lw+Jv9Yf6eMoOX5ooXPXyf2+rS7RIA=="
     },
     "@jest/console": {
       "version": "24.7.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls"
   },
   "dependencies": {
-    "@glimmer/syntax": "^0.41.0",
+    "@glimmer/syntax": "^0.41.1",
     "codemod-cli": "^1.0.0",
     "prettier": "^1.18.2"
   },

--- a/transforms/angle-brackets/__testfixtures__/curly.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/curly.input.hbs
@@ -1,0 +1,2 @@
+<div>{{foo}}</div>
+<div>{{{bar}}}</div>

--- a/transforms/angle-brackets/__testfixtures__/curly.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/curly.output.hbs
@@ -1,0 +1,6 @@
+<div>
+  {{foo}}
+</div>
+<div>
+  {{{bar}}}
+</div>

--- a/transforms/angle-brackets/__testfixtures__/custom-options-js.config.js
+++ b/transforms/angle-brackets/__testfixtures__/custom-options-js.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "helpers": ["some-helper1", "some-helper2", "some-helper3"],
+  "skipBuiltInComponents": true
+};

--- a/transforms/angle-brackets/__testfixtures__/custom-options-js.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options-js.input.hbs
@@ -1,0 +1,6 @@
+{{some-component foo=true}}
+{{some-helper1 foo=true}}
+{{some-helper2 foo=true}}
+{{link-to "Title" "some.route"}}
+{{textarea value=this.model.body}}
+{{input type="checkbox" name="email-opt-in" checked=this.model.emailPreference}}

--- a/transforms/angle-brackets/__testfixtures__/custom-options-js.options.json
+++ b/transforms/angle-brackets/__testfixtures__/custom-options-js.options.json
@@ -1,0 +1,3 @@
+{
+  "config": "./transforms/angle-brackets/__testfixtures__/custom-options-js.config.js"
+}

--- a/transforms/angle-brackets/__testfixtures__/custom-options-js.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options-js.output.hbs
@@ -1,0 +1,6 @@
+<SomeComponent @foo={{true}} />
+{{some-helper1 foo=true}}
+{{some-helper2 foo=true}}
+{{link-to "Title" "some.route"}}
+{{textarea value=this.model.body}}
+{{input type="checkbox" name="email-opt-in" checked=this.model.emailPreference}}

--- a/transforms/angle-brackets/__testfixtures__/sample2.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/sample2.input.hbs
@@ -3,4 +3,6 @@
   {{#card.content}}
     <p>hello</p>
   {{/card.content}}
+  {{card.foo-bar}}
+  {{card.foo}}
 {{/my-card}}

--- a/transforms/angle-brackets/__testfixtures__/sample2.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/sample2.output.hbs
@@ -5,4 +5,6 @@
       hello
     </p>
   </card.content>
+  <card.foo-bar />
+  {{card.foo}}
 </MyCard>

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -161,7 +161,7 @@ const isAttribute = key => {
 }
 
 const isNestedComponentTagName = tagName => {
-  return tagName && tagName.includes && tagName.includes('/');
+  return tagName && tagName.includes && (tagName.includes('/') || tagName.includes('-'));
 }
 
 /**

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -12,7 +12,7 @@ class Config {
 
     if (options.config) {
       let filePath = path.join(process.cwd(), options.config);
-      let config = JSON.parse(fs.readFileSync(filePath));
+      let config = this.getConfig(filePath);
 
       if (config.helpers) {
         this.helpers = config.helpers;
@@ -23,6 +23,14 @@ class Config {
       }
 
       this.skipBuiltInComponents = !!config.skipBuiltInComponents;
+    }
+  }
+
+  getConfig(filePath) {
+    if (filePath.endsWith('.js')) {
+      return require(filePath);
+    } else {
+      return JSON.parse(fs.readFileSync(filePath));
     }
   }
 }


### PR DESCRIPTION
I have a use case where I'd like to use a .js file as my configuration file.

In my case I have the list of application helpers as an exported node lib so I can reuse it in this codemod as well as some custom linting rules. This change enables that ability.